### PR TITLE
chore: #22 gonの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
   gem "rails_live_reload"
+  gem "swimming_fish", "~> 0.2.2"
 end
 
 group :test do
@@ -62,3 +63,4 @@ end
 gem "devise"
 gem "rails-i18n"
 gem "devise-i18n"
+gem "gon"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,11 @@ GEM
     ffi (1.17.2-x86_64-linux-musl)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    gon (6.5.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)
@@ -158,6 +163,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.26.0)
     msgpack (1.8.0)
+    multi_json (1.17.0)
     net-imap (0.5.12)
       date
       net-protocol
@@ -264,6 +270,8 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.2)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
@@ -316,6 +324,7 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
+    swimming_fish (0.2.2)
     thor (1.4.0)
     timeout (0.4.3)
     tsort (0.2.0)
@@ -363,6 +372,7 @@ DEPENDENCIES
   debug
   devise
   devise-i18n
+  gon
   jbuilder
   jsbundling-rails
   pg (~> 1.1)
@@ -374,6 +384,7 @@ DEPENDENCIES
   selenium-webdriver
   sprockets-rails
   stimulus-rails
+  swimming_fish (~> 0.2.2)
   turbo-rails
   tzinfo-data
   web-console


### PR DESCRIPTION
## 概要
RailsアプリケーションとJavaScript間でデータを受け渡すためのgonを導入しました。

## 作業内容
- `gem "gon"`を追加

## 対応Issue
- close #22

## 関連Issue
なし

## 備考
なし