### PR TITLE
refactor: コメント一覧のrender記法をpartial形式へ統一

### DIFF
--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -250,7 +250,7 @@
     <!-- コメント一覧 -->
     <div class="space-y-4">
       <div class="space-y-4" id="review_comments">
-        <%= render @review_comments %>
+        <%= render partial: "review_comments/review_comment", collection: @review_comments %>
         <% if @review_comments.blank? %>
           <div class="card bg-base-100 border border-base-300 mb-4" id="review_comments_empty_state">
             <div class="card-body">


### PR DESCRIPTION
## 概要
レビュー詳細ページのコメント一覧描画を`render partial: ..., collection:`形式へ統一する。

## 作業内容
- コメント一覧部分のrender記法を修正

## 対応Issue
なし

## 関連Issue
なし

## 備考
なし