### PR TITLE
fix: ダークモード対応を無効化

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -13,7 +13,7 @@
 @plugin "daisyui/theme" {
   name: "clagi-gokoro";
   default: true;
-  prefersdark: false;
+  prefersdark: true;
   color-scheme: "light";
   --color-base-100: #FDFCFA;
   --color-base-200: #F7F2E8;


### PR DESCRIPTION
## 概要
daisyUIの自動ダークモード対応を無効化しました。

## 作業内容
- daisyUIの自動ダークモード対応を無効化

## 対応Issue
- close #135

## 関連Issue
なし

## 備考
ダークモードで配色を変更するかはMVP後に検討する。