### PR TITLE
fix: レビューコメントの関連付けを削除

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,7 +1,6 @@
 class Review < ApplicationRecord
   belongs_to :user
   belongs_to :song
-  has_many :review_comments, dependent: :destroy
 
   RATING_ATTRIBUTES = %i[
     tempo_rating

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :reviews, dependent: :destroy
-  has_many :review_comments, dependent: :destroy
 
   validates :name, presence: true
   validates :name, uniqueness: true, length: { in: 2..15 }, allow_blank: true


### PR DESCRIPTION
## 概要
不要となったレビューコメント機能に紐づく関連をモデルから削除。

## 作業内容
- userモデルからレビューコメントの関連付けを削除
- reviewモデルからレビューコメントの関連付けを削除

## 対応Issue
- close #141

## 関連Issue
なし

## 備考
なし