### PR TITLE
fix: レビュー一覧カードのグラフのツールチップ無効化

### DIFF
--- a/app/javascript/controllers/review_chart_controller.js
+++ b/app/javascript/controllers/review_chart_controller.js
@@ -80,7 +80,7 @@ export default class extends Controller {
             display: false
           },
           tooltip: {
-            enabled: true
+            enabled: false
           }
         }
       }


### PR DESCRIPTION
## 概要
レビュー一覧に表示されるレーダーチャートの不要なツールチップ表示を無効化しました。

## 作業内容
- Chart.js設定でtooltip.enabledをfalseに設定

## 対応Issue
- close #154

## 関連Issue
なし

## 備考
なし