### PR TITLE
fix: 値存在チェックを削除

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -10,9 +10,7 @@ class Review < ApplicationRecord
     memorization_rating
   ].freeze
 
-  validates *RATING_ATTRIBUTES, presence: true
-  validates *RATING_ATTRIBUTES, inclusion: { in: 1..5 }, allow_blank: true
-
+  validates *RATING_ATTRIBUTES, inclusion: { in: 1..5, message: "は1から5の間で評価してください" }
   validates :song_id, uniqueness: { scope: :user_id, message: "に対してレビュー済みです。" }
 
   before_save :calc_overall_rating
@@ -20,7 +18,10 @@ class Review < ApplicationRecord
   private
 
   def calc_overall_rating
-    ratings = RATING_ATTRIBUTES.map { |attr| self[attr] || 0 }
+    # 全ての評価が存在する場合のみ計算
+    return unless RATING_ATTRIBUTES.all? { |attr| self[attr].present? }
+
+    ratings = RATING_ATTRIBUTES.map { |attr| self[attr] }
     self.overall_rating = (ratings.sum.to_f / ratings.size).round
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,5 @@ class User < ApplicationRecord
 
   has_many :reviews, dependent: :destroy
 
-  validates :name, presence: true
-  validates :name, uniqueness: true, length: { in: 2..15 }, allow_blank: true
+  validates :name, uniqueness: true, length: { in: 2..15 }
 end


### PR DESCRIPTION
## 概要
user, reviewモデルで`presence: true`と他バリデーションの重複によりエラーメッセージが複数表示される問題を修正。

## 作業内容
- userモデル:`presence: true`を削除
- reviewモデル:`presence: true`を削除

## 対応Issue
- close #162

## 関連Issue
なし

## 備考
なし