### PR TITLE
fix: 新規登録フォームのautocomplete属性を修正

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -12,7 +12,7 @@
 
       <div class="mb-4 md:mb-6">
         <%= f.label :password, class: "label" %>
-        <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワードを入力", class: "w-full input" %>
+        <%= f.password_field :password, autocomplete: "current-password", placeholder: "パスワードを入力", class: "w-full input" %>
       </div>
 
       <% if devise_mapping.rememberable? %>


### PR DESCRIPTION
## 概要
ログイン画面のパスワードフィールドのautocomplete属性の設定を変更しました。

## 作業内容
- ログイン画面: autocomplete: "current-password" に設定

## 対応Issue
なし

## 関連Issue
なし

## 備考
なし