### PR TITLE
fix: reviewsテーブルに重複防止を追加

### DIFF
--- a/db/migrate/20251119151237_add_unique_index_to_reviews.rb
+++ b/db/migrate/20251119151237_add_unique_index_to_reviews.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToReviews < ActiveRecord::Migration[7.2]
+  def change
+    add_index :reviews, [:user_id, :song_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_02_072617) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_19_151237) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_02_072617) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["song_id"], name: "index_reviews_on_song_id"
+    t.index ["user_id", "song_id"], name: "index_reviews_on_user_id_and_song_id", unique: true
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
同一ユーザーが同じ楽曲に対して複数レビューを投稿することを防ぐため、データベースレベルでのユニーク制約を追加。

## 作業内容
- データベースレベルでの重複レビュー投稿を制御

## 対応Issue
なし

## 関連Issue
なし

## 備考
なし