### PR TITLE
chore: マイグレーションのデプロイエラーを修正

### DIFF
--- a/db/migrate/20251122080029_add_song_uuid_to_reviews.rb
+++ b/db/migrate/20251122080029_add_song_uuid_to_reviews.rb
@@ -1,15 +1,21 @@
 class AddSongUuidToReviews < ActiveRecord::Migration[7.2]
-  def change
+  def up
     add_column :reviews, :song_uuid, :uuid
     add_index :reviews, :song_uuid
 
     # 既存データの移行
-    Review.reset_column_information
-    Review.find_each do |review|
-      review.update_column(:song_uuid, Song.find(review.song_id).uuid)
-    end
+    execute <<~SQL
+      UPDATE reviews
+      SET song_uuid = songs.uuid
+      FROM songs
+      WHERE reviews.song_id = songs.id;
+    SQL
 
     # null制約を追加
     change_column_null :reviews, :song_uuid, false
+  end
+
+  def down
+    remove_column :reviews, :song_uuid
   end
 end


### PR DESCRIPTION
## 概要
本番デプロイ時にマイグレーション実行でエラーが発生したため、PostgreSQL互換性とデータ移行処理の安全性を向上。

## 作業内容
- PostgreSQL環境でのSQL文法互換性を改善
- データ移行処理の安全性向上

## 対応Issue
- close #166

## 関連Issue
なし

## 備考
なし