### PR TITLE
chore: マイグレーションエラーを修正してSQLクエリを使用

### DIFF
--- a/db/migrate/20251122080029_add_song_uuid_to_reviews.rb
+++ b/db/migrate/20251122080029_add_song_uuid_to_reviews.rb
@@ -1,15 +1,24 @@
 class AddSongUuidToReviews < ActiveRecord::Migration[7.2]
-  def change
+  # マイグレーション内でモデルを定義
+  def up
     add_column :reviews, :song_uuid, :uuid
     add_index :reviews, :song_uuid
 
     # 既存データの移行
     Review.reset_column_information
-    Review.find_each do |review|
-      review.update_column(:song_uuid, Song.find(review.song_id).uuid)
-    end
 
-    # null制約を追加
+    # 直接SQLを使用する方法
+    execute <<-SQL
+      UPDATE reviews
+      SET song_uuid = songs.uuid
+      FROM songs
+      WHERE reviews.song_id = songs.id
+    SQL
+
     change_column_null :reviews, :song_uuid, false
+  end
+
+  def down
+    remove_column :reviews, :song_uuid
   end
 end


### PR DESCRIPTION
## 概要
UUIDマイグレーション実行時に本番環境で発生したエラーを解消するため、
SQLクエリの記法と実行方法を改善。

## 作業内容
- マイグレーション内のSQL文法をPostgreSQL本番環境に対応
- データ移行処理のSQLクエリを安全で確実な記法に変更

## 対応Issue
- close #166

## 関連Issue
なし

## 備考
なし