### PR TITLE
feat: 既存ユーザーのconfirmable対応データ移行

### DIFF
--- a/db/migrate/20251124165214_backfill_confirmed_at_for_users.rb
+++ b/db/migrate/20251124165214_backfill_confirmed_at_for_users.rb
@@ -1,0 +1,17 @@
+class BackfillConfirmedAtForUsers < ActiveRecord::Migration[7.2]
+  class User < ApplicationRecord
+    self.table_name = "users"
+  end
+
+  def up
+    User.reset_column_information
+    now = Time.current
+
+    User.where(confirmed_at: nil).find_each do |user|
+      user.update_columns(
+        confirmed_at: now,
+        confirmation_sent_at: user.confirmation_sent_at || now
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_24_163449) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_24_170000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
## 概要
Devise confirmable機能導入に伴い、既存ユーザーのデータ整合性を確保するためのデータ移行を実施。

## 作業内容
- confirmed_atがnullの既存ユーザーデータの一括更新
- 現在時刻でconfirmed_at、confirmation_sent_atを設定

## 対応Issue
- close #156

## 関連Issue
なし

## 備考
なし