### PR TITLE
fix: 読み取り専用textareaをdivに変更

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -60,9 +60,9 @@
           <div class="card-body p-6 md:p-8">
             <h3 class="text-xl sm:text-2xl font-serif font-medium text-primary mb-4">自己紹介</h3>
 
-            <textarea readonly
-                      class="textarea textarea-bordered w-full resize-none bg-base-50"
-                      rows="10"><%= @user.self_introduction.presence || "自己紹介を追加してみましょう" %></textarea>
+            <div class="textarea textarea-bordered w-full bg-base-50 break-words" style="height: 16rem; max-height: 16rem; overflow-y: auto; white-space: pre-wrap;"><%=
+              @user.self_introduction.presence || "自己紹介を追加してみましょう"
+            %></div>
           </div>
         </div>
 

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -99,10 +99,10 @@
 
             <%# 投稿者コメント %>
             <div class="mt-2">
-              <label class="font-serif font-medium text-primary text-base mb-2">投稿者コメント</label>
-              <textarea readonly
-                        class="textarea textarea-bordered w-full resize-none bg-base-50"
-                        rows="10"><%= @review.summary.presence || "コメントはありません" %></textarea>
+              <label class="block font-serif font-medium text-primary text-base mb-2">投稿者コメント</label>
+              <div class="textarea textarea-bordered w-full bg-base-50 break-words" style="height: 16rem; max-height: 16rem; overflow-y: auto; white-space: pre-wrap;"><%=
+                @review.summary.presence || "コメントはありません"
+              %></div>
             </div>
           </div>
         </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,9 +15,9 @@
           <div class="card-body p-6 md:p-8">
             <h3 class="text-xl sm:text-2xl font-serif font-medium text-primary mb-4">自己紹介</h3>
 
-            <textarea readonly
-                      class="textarea textarea-bordered w-full resize-none bg-base-50"
-                      rows="10"><%= @user.self_introduction.presence || "自己紹介はまだ登録されていません" %></textarea>
+            <div class="textarea textarea-bordered w-full bg-base-50 break-words" style="height: 16rem; max-height: 16rem; overflow-y: auto; white-space: pre-wrap;"><%=
+              @user.self_introduction.presence || "自己紹介はまだ登録されていません"
+            %></div>
           </div>
         </div>
 


### PR DESCRIPTION
## 概要
読み取り専用のテキスト表示において、`textarea`要素を`div`要素に変更しました。

## 作業内容
- 以下のページで読み取り専用`textarea`を`div`に置き換え
  - プロフィールページ
  - ユーザー詳細ページ
  - レビュー詳細ページ
- 固定の高さ(16rem)とスクロール機能を追加

## 対応Issue
なし

## 関連Issue
なし

## 備考
なし