### PR TITLE
fix: アカウント削除ボタンの幅を修正

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -84,7 +84,7 @@
               </p>
             </div>
             <%= render "account_delete_modal" do %>
-              <button data-action="auto-modal#show" class="btn btn-error text-base-100 w-full md:w-auto shadow-md hover:shadow-lg transition-all hover:-translate-y-0.5 rounded-full">
+              <button data-action="auto-modal#show" class="btn btn-error text-base-100 w-full shadow-md hover:shadow-lg transition-all hover:-translate-y-0.5 rounded-full">
                 <%= t("devise.registrations.edit.cancel_my_account") %>
               </button>
             <% end %>


### PR DESCRIPTION
## 概要
アカウント削除ボタンの幅を修正しました。

## 作業内容
- アカウント削除ボタンの幅を修正

## 対応Issue
なし

## 関連Issue
- #251

## 備考
なし