### PR TITLE
fix: モバイルデザインでタグ選択時にズームされるのを防ぐ調整

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -56,6 +56,13 @@
   align-self: center;
 }
 
+/* モバイルデザインで入力時にズームされるのを防ぐ調整 */
+@media (pointer: coarse) and (max-width: 768px) {
+  .tagify__input {
+    font-size: 1rem;
+  }
+}
+
 .tagify__tag {
   max-width: 100%;
 }


### PR DESCRIPTION
## 概要
モバイルデザインでタグ選択時にズームされるのを防ぐ調整しました。

## 作業内容
- モバイルデザインでタグ選択時にズームされるのを防ぐ調整

## 対応Issue
なし

## 関連Issue
なし

## 備考
なし