### PR TITLE
fix: メールアドレス変更の説明文に改行を付与

### DIFF
--- a/app/views/users/email_changes/edit.html.erb
+++ b/app/views/users/email_changes/edit.html.erb
@@ -40,7 +40,8 @@
                                   class: "input input-bordered w-full bg-base-50 focus:bg-white transition-colors",
                                   autocomplete: "email" %>
                 <p class="text-sm text-neutral/60 mt-2">
-                  入力したメールアドレスに確認メールを送信します。メールに記載されたリンクをクリックすると変更が完了します。
+                  入力したメールアドレスに確認メールを送信します。<br>
+                  メールに記載されたリンクをクリックすると変更が完了します。
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## 概要
メールアドレス変更の説明文に改行を付与しました。

## 作業内容
- メールアドレス変更の説明文に改行を付与

## 対応Issue
なし

## 関連Issue
なし

## 備考
なし